### PR TITLE
fix: correct entry point definition to load module instead of function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ Repository = "https://github.com/rtk-ai/rtk"
 Issues = "https://github.com/rtk-ai/rtk/issues"
 
 [project.entry-points."hermes_agent.plugins"]
-rtk-rewrite = "rtk_hermes:register"
+rtk-rewrite = "rtk_hermes"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
The entry point in `pyproject.toml` is defined as:

```toml
rtk-rewrite = "rtk_hermes:register"
```

This causes the plugin to silently fail on startup with:

```
WARNING hermes_cli.plugins: Plugin 'rtk-rewrite' has no register() function
Plugin discovery complete: 1 found, 0 enabled
```

## Root cause

Hermes's plugin loader calls `ep.load()` on the entry point and expects to receive a **module** with a `register(ctx)` attribute. The `:register` suffix tells `importlib.metadata` to resolve and return the `register` **function** directly — not the module. The loader then does `getattr(loaded_function, 'register', None)` which returns `None`, so the plugin is skipped.

```
ep.load() → <function register at 0x...>   # returns the function
getattr(function, 'register', None) → None  # not a module, no attrs
→ 'no register() function' warning         # plugin disabled
```

## Fix

Remove the `:register` suffix so `ep.load()` returns the `rtk_hermes` module. The loader then finds `register()` on the module as expected:

```toml
rtk-rewrite = "rtk_hermes"
```

This matches how Hermes's `_load_entrypoint_module` + `_load_plugin` are designed to work — consistent with directory-based plugins that provide a module containing `register(ctx)`.

## Verification

After the fix, Hermes startup shows:

```
INFO rtk_hermes: [rtk] Hermes plugin registered
Plugin discovery complete: 1 found, 1 enabled
```

## Diff

```diff
- rtk-rewrite = "rtk_hermes:register"
+ rtk-rewrite = "rtk_hermes"
```