### PR TITLE
fix: accept RTK exit code 3 as successful rewrite

### DIFF
--- a/src/rtk_hermes/__init__.py
+++ b/src/rtk_hermes/__init__.py
@@ -39,7 +39,16 @@ def _check_rtk() -> bool:
 
 
 def _try_rewrite(command: str) -> Optional[str]:
-    """Delegate to `rtk rewrite` and return the rewritten command, or None."""
+    """Delegate to `rtk rewrite` and return the rewritten command, or None.
+
+    RTK exit code protocol (src/hooks/rewrite_cmd.rs):
+      0 = rewrite allowed (auto-allow)
+      1 = no RTK equivalent (passthrough)
+      2 = deny rule matched
+      3 = ask rule matched — rewrite exists but needs confirmation
+
+    Both 0 and 3 produce valid rewritten output on stdout.
+    """
     try:
         result = subprocess.run(
             ["rtk", "rewrite", command],
@@ -48,7 +57,8 @@ def _try_rewrite(command: str) -> Optional[str]:
             timeout=2,
         )
         rewritten = result.stdout.strip()
-        if result.returncode == 0 and rewritten and rewritten != command:
+        # Accept exit 0 (allow) and 3 (ask) as successful rewrites
+        if result.returncode in (0, 3) and rewritten and rewritten != command:
             return rewritten
         return None
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):


### PR DESCRIPTION
## Problem

The plugin checks  to determine if a rewrite succeeded. However,  returns **exit code 3** for successful rewrites when the permission verdict is  or  (which is the default for most commands without explicit allow rules). This causes the plugin to silently ignore all rewrites.

Fixes #2

## RTK Exit Code Protocol

Per :

| Exit Code | Meaning |
|-----------|---------|
| 0 | Rewrite allowed (auto-allow) |
| 1 | No RTK equivalent (passthrough) |
| 2 | Deny rule matched |
| 3 | Ask rule matched — rewrite exists but needs confirmation |

Exit code 3 is intentional and used by the Claude Code hook (). Both 0 and 3 produce valid rewritten output on stdout.

## Changes

- Accept both exit codes 0 and 3 as successful rewrites
- Document the RTK exit code protocol in the docstring

## Verification

Tested with rtk v0.37.2:

* main...origin/main
clean — nothing to commit

With this fix, the plugin correctly accepts the rewrite.

---

**Note:** I also discovered that Hermes v0.11.0 doesn't scan Python  for plugin discovery — it only looks for  in . The pip package alone isn't enough; users need either a symlink or manual  setup. Happy to open a separate issue/PR for that if useful.