### PR TITLE
fix(rtk_hermes): drop returncode==0 check in _try_rewrite

### DIFF
--- a/src/rtk_hermes/__init__.py
+++ b/src/rtk_hermes/__init__.py
@@ -48,7 +48,7 @@ def _try_rewrite(command: str) -> Optional[str]:
             timeout=2,
         )
         rewritten = result.stdout.strip()
-        if result.returncode == 0 and rewritten and rewritten != command:
+        if rewritten and rewritten != command:
             return rewritten
         return None
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -43,6 +43,11 @@ class TestTryRewrite:
         with patch("subprocess.run", return_value=self._fake("echo hello\n")):
             assert rtk_hermes._try_rewrite("echo hello") is None
 
+    def test_exit_3_ask_returns_rewrite(self):
+        """Exit code 3 (ask) is a valid rewrite — must not be dropped."""
+        with patch("subprocess.run", return_value=self._fake("rtk ls -la /tmp\n", rc=3)):
+            assert rtk_hermes._try_rewrite("ls -la /tmp") == "rtk ls -la /tmp"
+
     def test_exit_1_returns_none(self):
         with patch("subprocess.run", return_value=self._fake("", rc=1)):
             assert rtk_hermes._try_rewrite("custom_cmd") is None


### PR DESCRIPTION
The rtk rewrite command uses a four-state exit code protocol (0=allow, 1=passthrough, 2=deny, 3=ask). Most valid rewrites (e.g. ls -> rtk ls, git status -> rtk git status) return exit code 3 because the hook runs in interactive mode and needs user confirmation.

The previous check 'returncode == 0' discarded all exit code 3 rewrites, making every valid rewrite silently dropped and the plugin effectively non-functional.

Replaced the exit-code check with a simple stdout check: rtk rewrite only emits non-empty stdout when a valid rewrite exists — empty stdout means no rewrite is available. This correctly handles all four exit codes.

Added a regression test 'test_exit_3_ask_returns_rewrite' to prevent future regression. All 27 tests pass.