### PR TITLE
fix: reject malformed RTK rewrite output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `rtk-hermes` are documented here.
 
+## Unreleased
+
+### Security
+
+- Reject malformed `rtk rewrite` stdout containing embedded newlines, carriage returns or NUL bytes so diagnostic or corrupted output cannot be executed as extra shell statements.
+
 ## 1.2.3 - 2026-05-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The plugin should never block command execution.
 | Terminal backend is not enabled by `RTK_HERMES_BACKENDS` | Original command runs unchanged. |
 | `rtk rewrite` times out | Original command runs unchanged. |
 | `rtk rewrite` crashes | Original command runs unchanged. |
+| `rtk rewrite` emits multiline or NUL-containing stdout | Original command runs unchanged; output is redacted in logs. |
 | No RTK equivalent | Original command runs unchanged. |
 | Unexpected RTK exit code | Warning is logged; original command runs unchanged. |
 

--- a/src/rtk_hermes/__init__.py
+++ b/src/rtk_hermes/__init__.py
@@ -65,6 +65,7 @@ class RtkHermesMetrics:
     timeouts: int = 0
     errors: int = 0
     unexpected_exit_codes: int = 0
+    malformed_output: int = 0
     missing_rtk: int = 0
     skipped_backend: int = 0
     total_rewrite_ms: float = 0.0
@@ -178,6 +179,25 @@ def _backend_enabled(backend: str, config: RtkHermesConfig) -> bool:
     return "all" in enabled or backend in enabled
 
 
+def _normalize_rewrite_output(stdout: str) -> Optional[str]:
+    """Return a safe single-line RTK rewrite, or None.
+
+    Hermes passes terminal commands to a shell. A rewritten command containing
+    embedded newlines, carriage returns or NUL bytes could execute additional
+    shell statements if RTK ever emitted diagnostic text or malformed output on
+    stdout. Keep the fail-open contract: reject malformed rewrites and let the
+    original command run unchanged.
+    """
+    rewritten = stdout.strip()
+    if not rewritten:
+        return None
+    if any(ch in rewritten for ch in ("\n", "\r", "\x00")):
+        _metrics.malformed_output += 1
+        logger.warning("[rtk] malformed `rtk rewrite` stdout rejected; output redacted")
+        return None
+    return rewritten
+
+
 def _try_rewrite(command: str, *, config: RtkHermesConfig | None = None) -> Optional[str]:
     """Delegate to `rtk rewrite` and return the rewritten command, or None."""
     cfg = config or _load_config()
@@ -190,7 +210,7 @@ def _try_rewrite(command: str, *, config: RtkHermesConfig | None = None) -> Opti
             text=True,
             timeout=cfg.timeout_ms / 1000,
         )
-        rewritten = result.stdout.strip()
+        rewritten = _normalize_rewrite_output(result.stdout)
         if result.returncode in _RTK_REWRITE_OK_CODES and rewritten and rewritten != command:
             return rewritten
         if result.returncode == 1:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -191,6 +191,23 @@ class TestTryRewrite:
         with patch("subprocess.run", return_value=self._fake("  rtk ls  \n")):
             assert rtk_hermes._try_rewrite("ls") == "rtk ls"
 
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            "rtk git status\necho leaked\n",
+            "rtk git status\r\necho leaked\r\n",
+            "rtk git status\x00echo leaked",
+        ],
+    )
+    def test_rejects_malformed_multiline_rewrite_output(self, stdout, caplog):
+        with patch("subprocess.run", return_value=self._fake(stdout, rc=0)):
+            with caplog.at_level("WARNING", logger="rtk_hermes"):
+                assert rtk_hermes._try_rewrite("git status") is None
+        assert rtk_hermes._metrics.malformed_output == 1
+        assert "malformed `rtk rewrite` stdout rejected" in caplog.text
+        assert "echo leaked" not in caplog.text
+        assert "git status" not in caplog.text
+
     def test_passes_command_as_arg_and_timeout(self):
         cfg = rtk_hermes.RtkHermesConfig(timeout_ms=500)
         with patch("subprocess.run", return_value=self._fake("", rc=1)) as m:


### PR DESCRIPTION
## Summary
- Reject malformed `rtk rewrite` stdout containing embedded newlines, carriage returns, or NUL bytes.
- Keep the plugin fail-open by leaving the original command unchanged when malformed rewrite output is seen.
- Add a `malformed_output` metric and redacted warning so operators can diagnose the event without leaking command text.
- Document the graceful degradation behavior and add changelog entry.

## Why
Hermes passes terminal commands to a shell. If RTK ever emits diagnostic text, corrupted output, or a multi-line command on stdout, applying the whole string as the rewritten terminal command could execute unintended extra shell statements. This hardens the boundary between RTK stdout and Hermes command execution while preserving existing behavior for normal single-line rewrites with trailing whitespace.

## Test Plan
- `python -m pytest`
- `python -m build`
- `python -m twine check dist/*`

Local result: `61 passed`; both wheel and sdist passed `twine check`.
